### PR TITLE
attach wkwebview to keywindow so it stays active in background

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -122,6 +122,9 @@
         if(!IsAtLeastiOSVersion(@"9.0")) {
             return nil;
         }
+        // add to keyWindow to ensure it is 'active'
+        [UIApplication.sharedApplication.keyWindow addSubview:self.engineWebView];
+
         self.frame = frame;
         [GCDWebServer setLogLevel: kGCDWebServerLoggingLevel_Warning];
         self.webServer = [[GCDWebServer alloc] init];
@@ -205,6 +208,8 @@
     configuration.userContentController = userContentController;
 
     // re-create WKWebView, since we need to update configuration
+    // remove from keyWindow before recreating
+    [self.engineWebView removeFromSuperview];
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.frame configuration:configuration];
 
     #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
@@ -215,6 +220,9 @@
 
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;
+
+    // add to keyWindow to ensure it is 'active'
+    [UIApplication.sharedApplication.keyWindow addSubview:self.engineWebView];
 
     if (IsAtLeastiOSVersion(@"9.0") && [self.viewController isKindOfClass:[CDVViewController class]]) {
         wkWebView.customUserAgent = ((CDVViewController*) self.viewController).userAgent;


### PR DESCRIPTION
This stops wkwebview from instantly stopping all javascript processes when app is sent to the background by attaching it to a key window so that it is still seen as "active" even when in the background vs the default of instantly being considered inactive as it has no active window attached.

Makes it behave the same as UIWebview when app is sent to the background and removes the need for the background mode plugin making things more predictable for developers.

This DOES NOT keep the app alive beyond the normal OS enforced limits for background run time etc, you still need to have an appropriate background capability enabled in xcode and if you app is actually idle it will still be suspended exactly as it should.